### PR TITLE
Moved static variables to instance variables

### DIFF
--- a/mosspy/moss.py
+++ b/mosspy/moss.py
@@ -35,20 +35,20 @@ class Moss:
         "plsql")
     server = 'moss.stanford.edu'
     port = 7690
-    userid = None
-    options = {
-        "l": "c",
-        "m": 10,
-        "d": 0,
-        "x": 0,
-        "c": "",
-        "n": 250
-    }
-    basefiles = []
-    files = []
 
-    def __init__(self, userid, language = "c"):
+    def __init__(self, userid, language="c"):
         self.userid = userid
+        self.userid = None
+        self.options = {
+            "l": "c",
+            "m": 10,
+            "d": 0,
+            "x": 0,
+            "c": "",
+            "n": 250
+        }
+        self.basefiles = []
+        self.files = []
 
         if language in self.languages:
             self.options["l"] = language

--- a/mosspy/moss.py
+++ b/mosspy/moss.py
@@ -38,7 +38,6 @@ class Moss:
 
     def __init__(self, userid, language="c"):
         self.userid = userid
-        self.userid = None
         self.options = {
             "l": "c",
             "m": 10,


### PR DESCRIPTION
Variables declared outside the constructor are not instance variable, they are static to the class instead. That means that new instances of your library will have duplicate data.

For example, out students worked on two files. I wanted to send moss requests for each type of file separately, so I made two instances of your library. However, any files I added to one instance was duplicated in the other instance. 

This should fix that issue.