### PR TITLE
Convert to function call instead of lambda

### DIFF
--- a/mosspy/moss.py
+++ b/mosspy/moss.py
@@ -138,4 +138,4 @@ class Moss:
 
         f = open(path, 'w')
         f.write(content.decode())
-        f.close
+        f.close()


### PR DESCRIPTION
`f.close` does not do anything

I believe you were trying to do `f.close()`