### PR TITLE
adding a file size check so we don't trigger the 0 file size bug

### DIFF
--- a/mosspy/moss.py
+++ b/mosspy/moss.py
@@ -70,13 +70,13 @@ class Moss:
         self.options['x'] = opt
 
     def addBaseFile(self, file_path, display_name=None):
-        if os.path.isfile(file_path):
+        if os.path.isfile(file_path) and os.path.getsize(file_path) > 0:
             self.base_files.append((file_path, display_name))
         else:
             raise Exception("addBaseFile({}) => File Not Found".format(file_path))
 
     def addFile(self, file_path, display_name=None):
-        if os.path.isfile(file_path):
+        if os.path.isfile(file_path) and os.path.getsize(file_path) > 0:
             self.files.append((file_path, display_name))
         else:
             raise Exception("addFile({}) => File Not Found".format(file_path))


### PR DESCRIPTION
Currently, there appears to be an issue with the library (or MOSS itself?) where if you add a file that exists but has no contents, the moss.send() call appears to hang for a bit, then returns an empty string. Maybe the socket.send() in the uploadFile method call doesn't like sending 0 bytes?

I've just set it to ignore empty files in my program using this library, but I figured it may be useful to fix upstream!