### PR TITLE
Using utf-8 encoding. Use join to build path.

### DIFF
--- a/mosspy/download_report.py
+++ b/mosspy/download_report.py
@@ -39,8 +39,8 @@ def process_url(url, urls, base_url, path):
             if link not in urls:                    
                 urls.append(link)
 
-    f = open(path + file_name, 'w')
-    f.write(str(soup)) # saving soup will save updated href
+    f = open(os.path.join(path, file_name), 'w')
+    f.write(str(soup.decode('utf-8', 'ignore').replace(u'\xa9', u''))) # saving soup will save updated href
     f.close()
 
 def download_report(url, path, connections = 4, log_level=logging.DEBUG):


### PR DESCRIPTION
1. In `download_report.py`
When downloading http://moss.stanford.edu/results/305606753/ , I find an error.
![image](https://user-images.githubusercontent.com/11944144/47066214-f61d5b80-d217-11e8-9b92-1c1d723fab22.png)
This problem is fixed by:
```python
f.write(str(soup.decode('utf-8', 'ignore').replace(u'\xa9', u'')))
```

2. Also in `download_report.py`
When calling `download_report(url, path)`, if `path` is not end with `/`, the name of directory will become prefix of file.
For example, calling `download_report(url, "./result")` will get `./resultindex.html` and `./resultmatch0.html`.
This problem is fixed by:
```python
f = open(os.path.join(path, file_name), 'w')
```
