### PR TITLE
uploadFile() now closes file resource

### DIFF
--- a/mosspy/moss.py
+++ b/mosspy/moss.py
@@ -101,11 +101,11 @@ class Moss:
             display_name
         )
         s.send(message.encode())
-        content = open(file_path, "rb").read(size)
-        s.send(content)
+        with open(file_path, "rb") as f:
+            s.send(f.read(size))
 
     def send(self):
-        s = socket.socket() 
+        s = socket.socket()
         s.connect((self.server, self.port))
 
         s.send("moss {}\n".format(self.user_id).encode())


### PR DESCRIPTION
Added open-with-resources in uploadFile() to handle unclosed resource warning and improve performance in Python 3.6.7 / GCC 8.2.0 on linux