### PR TITLE
Fixed bug in display_name causing no results

### DIFF
--- a/mosspy/moss.py
+++ b/mosspy/moss.py
@@ -91,7 +91,8 @@ class Moss:
     def uploadFile(self, s, file_path, display_name, file_id):
         if display_name is None:
             # If no display name added by user, default to file path
-            display_name = file_path.replace(" ", "_")
+            # Display name cannot accept \, replacing it with /
+            display_name = file_path.replace(" ", "_").replace("\\", "/")
 
         size = os.path.getsize(file_path)
         message = "file {0} {1} {2} {3}\n".format(


### PR DESCRIPTION
Platform: Windows 10, using Powershell.

To replicate:
Setup your script as per example, with the following changes.
Call `addFilesByWildcard` with a directory ie. `{}\\*.h`

Then, send and download the report.
Report will be empty.

Re-running in Linux with `{}/*.h` would work, report will not be empty.

The issue is Moss Server cannot accept `\` character in the name, fixed by replacing it with the linux character `/`.