### PR TITLE
Add on_send, on_read lambdas for user-definable progress notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ m.addBaseFile("submission/test_student.py")
 m.addFile("submission/a01-sample.py")
 m.addFilesByWildcard("submission/a01-*.py")
 
-url = m.send() # Submission Report URL
+# progress function optional, run on every file uploaded
+# result is submission URL
+url = m.send(lambda file_path, display_name: print('*', end='', flush=True))
+print()
+
 
 print ("Report Url: " + url)
 
@@ -38,7 +42,9 @@ print ("Report Url: " + url)
 m.saveWebPage(url, "submission/report.html")
 
 # Download whole report locally including code diff links
-mosspy.download_report(url, "submission/report/", connections=8)
+mosspy.download_report(url, "submission/report/", connections=8, log_level=10, on_read=lambda url: print('*', end='', flush=True)) 
+# log_level=logging.DEBUG (20 to disable)
+# on_read function run for every downloaded file
 ```
 
 ## Python Compatibility

--- a/moss_usage.py
+++ b/moss_usage.py
@@ -12,11 +12,16 @@ m.addFile("submission/a01-sample.py")
 
 m.addFilesByWildcard("submission/a01-*.py")
 
-url = m.send() 
+# progress function optional, run on every file uploaded
+# result is submission URL
+url = m.send(lambda file_path, display_name: print('*', end='', flush=True))
+print()
 
 print ("Report URL: " + url)
 
 # Save report file
 m.saveWebPage(url, "submission/report.html")
 
-mosspy.download_report(url, "submission/report/", connections=8, log_level=10) # logging.DEBUG (20 to disable)
+mosspy.download_report(url, "submission/report/", connections=8, log_level=10, on_read=lambda url: print('*', end='', flush=True)) 
+# log_level=logging.DEBUG (20 to disable)
+# on_read function run for every downloaded file

--- a/mosspy/download_report.py
+++ b/mosspy/download_report.py
@@ -6,12 +6,13 @@ try:
 except ImportError:
     from urllib2 import urlopen
 
-def process_url(url, urls, base_url, path):
+def process_url(url, urls, base_url, path, on_read):
     from bs4 import BeautifulSoup # Backward compability, don't break Moss when bs4 not available.
 
     logging.debug ("Processing URL: " + url)
     response = urlopen(url)
     html = response.read()
+    on_read(url)
     soup = BeautifulSoup(html, 'lxml')
     file_name = os.path.basename(url)
 
@@ -49,7 +50,7 @@ def process_url(url, urls, base_url, path):
     f.write(soup.encode(soup.original_encoding))
     f.close()
 
-def download_report(url, path, connections = 4, log_level=logging.DEBUG):
+def download_report(url, path, connections = 4, log_level=logging.DEBUG, on_read=lambda url: None):
     logging.basicConfig(level=log_level)
 
     if len(url) == 0:
@@ -68,7 +69,7 @@ def download_report(url, path, connections = 4, log_level=logging.DEBUG):
 
     # Handling thread
     for url in urls:
-        t = Thread(target=process_url, args=[url, urls, base_url, path])
+        t = Thread(target=process_url, args=[url, urls, base_url, path, on_read])
         t.start()
         threads.append(t)
 

--- a/mosspy/moss.py
+++ b/mosspy/moss.py
@@ -1,7 +1,6 @@
 import os
 import socket
 import glob
-import logging
 
 try:
     from urllib.request import urlopen
@@ -89,7 +88,7 @@ class Moss:
     def getLanguages(self):
         return self.languages
 
-    def uploadFile(self, s, file_path, display_name, file_id):
+    def uploadFile(self, s, file_path, display_name, file_id, on_send):
         if display_name is None:
             # If no display name added by user, default to file path
             # Display name cannot accept \, replacing it with /
@@ -105,8 +104,9 @@ class Moss:
         s.send(message.encode())
         with open(file_path, "rb") as f:
             s.send(f.read(size))
+        on_send(file_path, display_name)
 
-    def send(self):
+    def send(self, on_send=lambda file_path, display_name: None):
         s = socket.socket()
         s.connect((self.server, self.port))
 
@@ -124,11 +124,11 @@ class Moss:
             raise Exception("send() => Language not accepted by server")
 
         for file_path, display_name in self.base_files:
-            self.uploadFile(s, file_path, display_name, 0)
+            self.uploadFile(s, file_path, display_name, 0, on_send)
 
         index = 1
         for file_path, display_name in self.files:
-            self.uploadFile(s, file_path, display_name, index)
+            self.uploadFile(s, file_path, display_name, index, on_send)
             index += 1
 
         s.send("query 0 {}\n".format(self.options['c']).encode())


### PR DESCRIPTION
I wanted to be able to put in a progress bar for uploads and downloads, so I added a lambda for a user-definable effect on uploads and downloads to Moss. The default value is `None`, so it should be backward-compatible, but `print('*', end='', flush=True)` is an example of a really simple progress tracking effect, or you can do something nicer-looking with a more-sophisticated progress bar library.