### PR TITLE
add url encoding parameter 

### DIFF
--- a/mosspy/moss.py
+++ b/mosspy/moss.py
@@ -145,8 +145,9 @@ class Moss:
             raise Exception("Empty url supplied")
 
         response = urlopen(url)
-        content = response.read()
+        charset = response.headers.get_content_charset()
+        content = response.read().decode(charset)
 
-        f = open(path, 'w')
-        f.write(content.decode())
+        f = open(path, 'w', encoding='utf-8')
+        f.write(content)
         f.close()


### PR DESCRIPTION
To prevent wrong encoding, when default coding is non-utf8